### PR TITLE
Updates on GetMIP/GetEnergyResolution processors

### DIFF
--- a/GetEnergyResolution/PlotResolution.cc
+++ b/GetEnergyResolution/PlotResolution.cc
@@ -1,0 +1,283 @@
+#include <TH1.h>
+#include <TStyle.h>
+#include <TCanvas.h>
+#include "TH1F.h"
+#include "TPad.h"
+#include "TRandom.h"
+#include "TMath.h"
+#include <cmath>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "LuxeStyle.h"
+#include "LuxeStyle.C"
+#include "LuxeLabels.h"
+#include "LuxeLabels.C"
+
+using namespace std;
+
+
+string const PROCESSOR_NAME = "EcalEResolution";
+string const FILE_LIST = "con_smearing.list";
+string ecalType[3] = {"smeared", "pixelised", "monolithic"};
+// string ecalType[3] = {"digitised", "pixelised", "monolithic"};
+
+vector<string> GetFileNames(string const path) {
+    ifstream filelist(path);
+    string filename;
+    vector<string> filenames;
+    while (getline(filelist, filename)) {
+        filenames.push_back(filename);
+    }
+    return filenames;
+}
+
+float GetRunEnergy(TFile* rootfile) {
+    TH1F* runInfo = (TH1F*) rootfile->Get(Form("%s/_runInfo", PROCESSOR_NAME.c_str()));
+    float energy = runInfo->GetBinContent(1);
+    return energy;
+}
+
+vector<TF1*> GetFitFuncsHits(TFile* rootfile) {
+    vector<TF1*> funcs;
+    TH1D* hists[2]; TF1* func;
+    hists[0] = (TH1D*) rootfile->Get(Form("%s/digit_evHitsHist", PROCESSOR_NAME.c_str()));
+    hists[1] = (TH1D*) rootfile->Get(Form("%s/pixel_evHitsHist", PROCESSOR_NAME.c_str()));
+    for (int i=0; i<2; i++) {
+        func = (TF1*) hists[i]->GetListOfFunctions()->FindObject("gaus");
+        funcs.push_back(func);
+    }
+    return funcs;
+}
+
+vector<TF1*> GetFitFuncsEnergy(TFile* rootfile) {
+    vector<TF1*> funcs;
+    TH1D* hists[3]; TF1* func;
+    hists[0] = (TH1D*) rootfile->Get(Form("%s/digit_evEnergyHist", PROCESSOR_NAME.c_str()));
+    hists[1] = (TH1D*) rootfile->Get(Form("%s/pixel_evEnergyHist", PROCESSOR_NAME.c_str()));
+    hists[2] = (TH1D*) rootfile->Get(Form("%s/mono_evEnergyHist", PROCESSOR_NAME.c_str()));
+    for (int i=0; i<3; i++) {
+        func = (TF1*) hists[i]->GetListOfFunctions()->FindObject("gaus");
+        funcs.push_back(func);
+    }
+    return funcs;
+}
+
+void PlotResolution() {
+    SetLuxeStyle();
+    
+    uint plotMarker[3] = {5,2,4};// "x" "+" "o" markers
+    map<float, double> energyMus[3], energySigmas[3];
+    map<float, double> hitsMus[2], hitsSigmas[2];
+    
+    vector<string> filenames = GetFileNames(FILE_LIST);
+    
+    for (string filename : filenames) {
+        cout<<"Processing file "<< filename <<endl;
+        TFile* rootfile = TFile::Open(filename.c_str());
+        float energy = GetRunEnergy(rootfile);
+        
+        vector<TF1*> energyfuncs = GetFitFuncsEnergy(rootfile);
+        for (int i=0; i<3; i++) {
+            energyMus[i][energy] = energyfuncs[i]->GetParameter(1);
+            energySigmas[i][energy] = energyfuncs[i]->GetParameter(2);
+        }
+        vector<TF1*> hitsfuncs = GetFitFuncsHits(rootfile);
+        for (int i=0; i<2; i++) {
+            hitsMus[i][energy] = hitsfuncs[i]->GetParameter(1);
+            hitsSigmas[i][energy] = hitsfuncs[i]->GetParameter(2);
+        }
+        rootfile->Close();
+    }
+    
+    TCanvas* canvas = new TCanvas("canvas", "", 800, 600);
+    // TCanvas* canvLin = new TCanvas("canvLin", "", 800, 600);
+    TCanvas* canvRes = new TCanvas("canvRes", "", 800, 600);
+    TCanvas* canvResiSqrt = new TCanvas("canvResiSqrt", "", 800, 600);
+    TF1* funcLin = new TF1("funcLin", "1/[0]*x^[1]");
+    TF1* funcRes = new TF1("funcRes", "sqrt([0]^2/x + ([1]/x)^2 + [2]^2)");
+    TF1* funcResiSqrt = new TF1("funcResiSqrt", "sqrt(([0]*x)^2 + ([1]*x^2)^2 + [2]^2)");
+    funcLin->SetParNames("p", "n");
+    funcLin->SetParameters(1., 1.); funcLin->SetParLimits(1, 0.1, 10);
+    funcLin->SetRange(1.0, 16.0); funcLin->SetLineStyle(9); funcLin->SetLineColor(kGray); funcLin->SetLineWidth(2);
+    funcRes->SetParNames("a", "b", "c");
+    funcRes->SetParameters(0.2, 0., 0.);
+    funcRes->SetRange(1.0, 16.0); funcRes->SetLineStyle(9); funcRes->SetLineColor(kGray); funcRes->SetLineWidth(2);
+    funcResiSqrt->SetParNames("a", "b", "c");
+    funcResiSqrt->SetParameters(0.2, 0., 0.);
+    funcResiSqrt->SetRange(0.2, 1.0); funcResiSqrt->SetLineStyle(9); funcResiSqrt->SetLineColor(kGray); funcResiSqrt->SetLineWidth(2);
+    
+    TGraph *energyRes[3], *energyResiSqrt[3]; TGraphErrors *energyLin[3];
+    for (int i=0; i<3; i++) {
+        energyLin[i] = new TGraphErrors();
+        energyLin[i]->SetTitle(Form("ECAL-E %s; E_{0} [GeV]; E_{dep} [GeV]", ecalType[i].c_str()));
+        energyRes[i] = new TGraph();
+        energyRes[i]->SetTitle(Form("ECAL-E %s energy resolution; E_{0} [GeV]; #sigma_{E}/E", ecalType[i].c_str()));
+        energyResiSqrt[i] = new TGraph();
+        energyResiSqrt[i]->SetTitle(Form("ECAL-E %s energy resolution; 1/#sqrt{E_{0}} [GeV^{-1/2}]; #sigma_{E}/E", ecalType[i].c_str()));
+        
+        for (const auto&[energy, mu] : energyMus[i]) {
+            energyLin[i]->AddPoint(energy, mu);
+            energyLin[i]->SetPointError(energyLin[i]->GetN()-1, 0., energySigmas[i][energy]);
+            energyRes[i]->AddPoint(energy, energySigmas[i][energy]/mu);
+            energyResiSqrt[i]->AddPoint(1./TMath::Sqrt(energy), energySigmas[i][energy]/mu);
+        }
+        
+        energyLin[i]->GetXaxis()->SetLimits(0, 16.5);
+        energyLin[i]->SetMinimum(0); energyLin[i]->SetMaximum(0.175);
+        if (i==0) {
+            energyLin[i]->GetYaxis()->SetTitle("E_{dep} [MIP]");
+            energyLin[i]->SetMinimum(0); energyLin[i]->SetMaximum(1250);
+        }
+        energyRes[i]->GetXaxis()->SetLimits(0, 16.5);
+        energyRes[i]->SetMinimum(0); energyRes[i]->SetMaximum(0.25);
+        energyResiSqrt[i]->GetXaxis()->SetLimits(0., 1.0);
+        energyResiSqrt[i]->SetMinimum(0); energyResiSqrt[i]->SetMaximum(0.25);
+        energyLin[i]->SetMarkerStyle(plotMarker[i]);
+        energyRes[i]->SetMarkerStyle(plotMarker[i]);
+        energyResiSqrt[i]->SetMarkerStyle(plotMarker[i]);
+        
+        if (i==0) {
+            canvRes->cd();
+            energyRes[i]->Draw("AP");
+            canvResiSqrt->cd();
+            energyResiSqrt[i]->Draw("AP");
+        } else {
+            canvRes->cd();
+            energyRes[i]->Draw("P SAME");
+            canvResiSqrt->cd();
+            energyResiSqrt[i]->Draw("P SAME");
+        }
+    }
+    // auto legendRes = new TLegend(0.2,0.2,0.45,0.45);
+    // legendRes->SetHeader("Energy resolution"); // option "C" allows to center the header
+    // legendRes->AddEntry(energyRes[2], Form("%s (energy)", ecalType[2].c_str()), "p");
+    // legendRes->AddEntry(energyRes[1], Form("%s (energy)", ecalType[1].c_str()), "p");
+    // legendRes->AddEntry(energyRes[0], Form("%s (energy)", ecalType[0].c_str()), "p");
+    // canvRes->cd();
+    // legendRes->Draw();
+    // canvRes->Print("energy_resolution_inverse_sqrt_smeared.pdf");
+    // canvRes->Clear();
+
+    // auto legendResiSqrt = new TLegend(0.2,0.6,0.45,0.85);
+    // legendResiSqrt->SetHeader("Energy resolution"); // option "C" allows to center the header
+    // legendResiSqrt->AddEntry(energyResiSqrt[2], Form("%s (energy)", ecalType[2].c_str()), "p");
+    // legendResiSqrt->AddEntry(energyResiSqrt[1], Form("%s (energy)", ecalType[1].c_str()), "p");
+    // legendResiSqrt->AddEntry(energyResiSqrt[0], Form("%s (energy)", ecalType[0].c_str()), "p");
+    // canvResiSqrt->cd();
+    // legendResiSqrt->Draw();
+    // canvResiSqrt->Print("energy_resolution_smeared.pdf");
+    // canvResiSqrt->Clear();
+    
+    TGraph *hitsRes[2], *hitsResiSqrt[2]; TGraphErrors *hitsLin[2];
+    for (int i=0; i<2; i++) {
+        hitsLin[i] = new TGraphErrors();
+        hitsLin[i]->SetTitle(Form("ECAL-E %s; E_{0} [GeV]; Hit", ecalType[i].c_str()));
+        hitsRes[i] = new TGraph();
+        hitsRes[i]->SetTitle(Form("ECAL-E %s hit resolution; E_{0} [GeV]; #sigma_{E}/E", ecalType[i].c_str()));
+        hitsResiSqrt[i] = new TGraph();
+        hitsResiSqrt[i]->SetTitle(Form("ECAL-E %s hit resolution; 1/#sqrt{E_{0}} [GeV^{-1/2}]; #sigma_{E}/E", ecalType[i].c_str()));
+        for (const auto&[energy, mu] : hitsMus[i]) {
+            hitsLin[i]->AddPoint(energy, mu);
+            hitsLin[i]->SetPointError(hitsLin[i]->GetN()-1, 0., hitsSigmas[i][energy]);
+            hitsRes[i]->AddPoint(energy, hitsSigmas[i][energy]/mu);
+            hitsResiSqrt[i]->AddPoint(1./TMath::Sqrt(energy), hitsSigmas[i][energy]/mu);
+        }
+        hitsLin[i]->GetXaxis()->SetLimits(0, 16.5);
+        hitsLin[i]->SetMinimum(0); hitsLin[i]->SetMaximum(250);
+        hitsRes[i]->GetXaxis()->SetLimits(0, 16.5);
+        hitsRes[i]->SetMinimum(0); hitsRes[i]->SetMaximum(0.25);
+        hitsResiSqrt[i]->GetXaxis()->SetLimits(0., 1.0);
+        hitsResiSqrt[i]->SetMinimum(0); hitsResiSqrt[i]->SetMaximum(0.25);
+        hitsLin[i]->SetMarkerStyle(plotMarker[i]);      hitsLin[i]->SetMarkerColor(kRed);
+        hitsRes[i]->SetMarkerStyle(plotMarker[i]);      hitsRes[i]->SetMarkerColor(kRed);
+        hitsResiSqrt[i]->SetMarkerStyle(plotMarker[i]); hitsResiSqrt[i]->SetMarkerColor(kRed);
+        
+        // if (i==0) {
+        //     canvRes->cd();
+        //     hitsRes[i]->Draw("AP");
+        //     canvResiSqrt->cd();
+        //     hitsResiSqrt[i]->Draw("AP");
+        // } else {
+            canvRes->cd();
+            hitsRes[i]->Draw("P SAME");
+            canvResiSqrt->cd();
+            hitsResiSqrt[i]->Draw("P SAME");
+        // }
+    }
+    auto legendRes = new TLegend(0.2,0.2,0.45,0.45);
+    legendRes->AddEntry(energyRes[2], Form("%s (energy)", ecalType[2].c_str()), "p");
+    legendRes->AddEntry(energyRes[1], Form("%s (energy)", ecalType[1].c_str()), "p");
+    legendRes->AddEntry(energyRes[0], Form("%s (energy)", ecalType[0].c_str()), "p");
+    legendRes->AddEntry(hitsRes[1], Form("%s (hit)", ecalType[1].c_str()), "p");
+    legendRes->AddEntry(hitsRes[0], Form("%s (hit)", ecalType[0].c_str()), "p");
+    canvRes->cd();
+    legendRes->Draw();
+    canvRes->Print(Form("resolution_%s.pdf", ecalType[0].c_str()));
+    canvRes->Clear();
+
+    auto legendResiSqrt = new TLegend(0.2,0.6,0.45,0.85);
+    legendResiSqrt->AddEntry(energyResiSqrt[2], Form("%s (energy)", ecalType[2].c_str()), "p");
+    legendResiSqrt->AddEntry(energyResiSqrt[1], Form("%s (energy)", ecalType[1].c_str()), "p");
+    legendResiSqrt->AddEntry(energyResiSqrt[0], Form("%s (energy)", ecalType[0].c_str()), "p");
+    legendResiSqrt->AddEntry(hitsResiSqrt[1], Form("%s (hit)", ecalType[1].c_str()), "p");
+    legendResiSqrt->AddEntry(hitsResiSqrt[0], Form("%s (hit)", ecalType[0].c_str()), "p");
+    canvResiSqrt->cd();
+    legendResiSqrt->Draw();
+    canvResiSqrt->Print(Form("resolution_inverse_sqrt_%s.pdf", ecalType[0].c_str()));
+    canvResiSqrt->Clear();
+
+    // legendRes->SetHeader("Hit resolution"); // option "C" allows to center the header
+    // canvRes->cd();
+    // legendRes->Draw();
+    // canvRes->Print("hits_resolution_inverse_sqrt.pdf");
+    // canvRes->Clear();
+
+    // legendResiSqrt->SetHeader("Hit resolution"); // option "C" allows to center the header
+    // canvResiSqrt->cd();
+    // legendResiSqrt->Draw();
+    // canvResiSqrt->Print("hits_resolution.pdf");
+    // canvResiSqrt->Clear();
+
+
+    for (int i=0; i<3; i++) {
+        canvas->cd();
+        energyLin[i]->Draw("AP");
+        energyLin[i]->Fit(funcLin, "R");
+        gStyle->SetOptFit(1);//probability, chisquare, error, value
+        canvas->Print(Form("energy_lin_ecale_%s.pdf", ecalType[i].c_str()));
+        canvas->Clear();
+        energyRes[i]->Draw("AP");
+        energyRes[i]->Fit(funcRes, "R");
+        gStyle->SetOptFit(1);//probability, chisquare, error, value
+        canvas->Print(Form("energy_res_ecale_%s.pdf", ecalType[i].c_str()));
+        canvas->Clear();
+        energyResiSqrt[i]->Draw("AP");
+        energyResiSqrt[i]->Fit(funcResiSqrt, "R");
+        gStyle->SetOptFit(1);//probability, chisquare, error, value
+        canvas->Print(Form("energy_res_inverse_sqrt_ecale_%s.pdf", ecalType[i].c_str()));
+        canvas->Clear();
+    }
+    
+    for (int i=0; i<2; i++) {
+        canvas->cd();
+        hitsLin[i]->Draw("AP");
+        hitsLin[i]->Fit(funcLin, "R");
+        gStyle->SetOptFit(1);//probability, chisquare, error, value
+        canvas->Print(Form("hit_lin_ecale_%s.pdf", ecalType[i].c_str()));
+        canvas->Clear();
+        hitsRes[i]->Draw("AP");
+        hitsRes[i]->Fit(funcRes, "R");
+        gStyle->SetOptFit(1);//probability, chisquare, error, value
+        canvas->Print(Form("hit_res_ecale_%s.pdf", ecalType[i].c_str()));
+        canvas->Clear();
+        hitsResiSqrt[i]->Draw("AP");
+        hitsResiSqrt[i]->Fit(funcResiSqrt, "R");
+        gStyle->SetOptFit(1);//probability, chisquare, error, value
+        canvas->Print(Form("hit_res_inverse_sqrt_ecale_%s.pdf", ecalType[i].c_str()));
+        canvas->Clear();
+    }
+    return;
+}

--- a/GetEnergyResolution/include/GetEnergyResolutionProcessor.hh
+++ b/GetEnergyResolution/include/GetEnergyResolutionProcessor.hh
@@ -43,9 +43,19 @@
 
 using namespace lcio;
 using namespace marlin;
+using namespace std;
 
-class GetEnergyResolutionProcessor : public Processor
-{
+class GetEnergyResolutionProcessor : public Processor {
+
+private:
+    const static int NUMBER_OF_LAYER = 15;
+    const static int NUMBER_OF_CELLX = 64;
+    const static int NUMBER_OF_CELLY = 32;
+    float FIT_INIT_AMP = 5000;//events
+    float FIT_INIT_MPV = 0.1e-3;//GeV
+    float FIT_INIT_SIG = 0.01e-3;//GeV
+    float E_RANGE_MIN = 0;
+    float E_RANGE_MAX = 0.05;//GeV
 
 public:
   virtual Processor *newProcessor() { return new GetEnergyResolutionProcessor; }
@@ -71,27 +81,64 @@ public:
 
   // Histogram definitions for ECALHit class
 
-  TH1* _xHist;
-  TH1* _yHist;
-  TH1* _zHist;
-  TH2* _xyHist;
-  TH2* _zxHist;
-  TH2* _zyHist;
-  TH1* _cellEnergyHist;
-  TH1* _evEnergyHist;
-  TH1* _evHitsHist;
-  TH1D* _hitsInLayer[15];
-  TH1F* _energyInLayerSi[15];
-  double _layerFitParams[15][4] = {0};
-  double energyRes;
-  int noHits=0;
-//private:
+    // MC particle
+    TH1* _runEnergy;
+    // Monolithic calorimeter hits
+    TH1* _zMonoHist;
+    TH1* _evMonoEnergyHist;
+    TH1* _energyInMonoLayerSi[NUMBER_OF_LAYER];
+    // Pixelised calorimeter hits
+    TH1* _xHist;
+    TH1* _yHist;
+    TH1* _zHist;
+    TH2* _xyHist;
+    TH2* _zxHist;
+    TH2* _zyHist;
+    TH1* _cellEnergyHist;
+    TH1* _evEnergyHist;
+    TH1* _evHitsHist;
+    TH1* _energyInLayerSi[NUMBER_OF_LAYER];
+    TH1* _hitsInLayer[NUMBER_OF_LAYER];
+    // Digitised calorimeter hits
+    TH1* _xDigitHist;
+    TH1* _yDigitHist;
+    TH1* _zDigitHist;
+    TH2* _xyDigitHist;
+    TH2* _zxDigitHist;
+    TH2* _zyDigitHist;
+    TH1* _cellDigitEnergyHist;
+    TH1* _evDigitEnergyHist;
+    TH1* _evDigitHitsHist;
+    TH1* _energyInDigitLayerSi[NUMBER_OF_LAYER];
+    TH1* _hitsInDigitLayer[NUMBER_OF_LAYER];
+    // double _layerFitParams[NUMBER_OF_LAYER][4];
+    // double energyRes;
+    
 
+private:
   virtual void ShowMCInfo(LCCollection *col);
   virtual void ShowECALInfo(LCCollection *col);
+    virtual void ShowPixelECALInfo(LCCollection *col);
+    virtual void ShowDigitECALInfo(LCCollection *col);
 
   std::string _MCColName;
   std::string _ECALColName;
+    std::string _pECALColName;
+    std::string _dECALColName;
+    
+    uint evHistBins = 31;
+    float radiusOverSigma = 2.0;//Fitting range == mean +- radius
+    vector<double> _evMonoEnergyVec;
+    vector<double> _evEnergyVec;
+    vector<int> _evHitsVec;
+    vector<double> _evDigitEnergyVec;
+    vector<int> _evDigitHitsVec;
+    
+    bool _flagMcCol = false;
+    bool _flagEcalCol = false;
+    bool _flagPixelEcalCol = false;
+    bool _flagDigitEcalCol = false;
+    float runEnergy = -1;
 
 
 };

--- a/GetEnergyResolution/scripts/test.xml
+++ b/GetEnergyResolution/scripts/test.xml
@@ -42,8 +42,10 @@
   </processor>
 
   <processor name="MyGetEnergyResolutionProcessor" type="GetEnergyResolutionProcessor">  
-    <parameter name="ECALCollectionName" type="string"> PixelSiEcalCollection </parameter>
     <parameter name="MCCollectionName" type="string"> MCParticle </parameter>
+    <parameter name="ECALCollectionName" type="string"> SiEcalCollection </parameter>
+    <parameter name="PixelisedECALCollectionName" type="string"> PixelSiEcalCollection </parameter>
+    <parameter name="DigitisedECALCollectionName" type="string"> EcalCollection </parameter>
   </processor>
 
 

--- a/GetEnergyResolution/src/GetEnergyResolutionProcessor.cc
+++ b/GetEnergyResolution/src/GetEnergyResolutionProcessor.cc
@@ -43,23 +43,23 @@ GetEnergyResolutionProcessor::GetEnergyResolutionProcessor() : Processor("GetEne
 	registerInputCollection(LCIO::MCPARTICLE,"MCCollectionName",
                             "Name of the MC collection",
 							_MCColName,
+							// std::string("MCParticle"));
 							std::string("Not configured in xml file"));
 	registerInputCollection(LCIO::SIMCALORIMETERHIT, "ECALCollectionName",
 							"Monolithic ECAL Hits Collection",
 							_ECALColName,
+							// std::string("SiEcalCollection"));
 							std::string("Not configured in xml file"));
 	registerInputCollection(LCIO::SIMCALORIMETERHIT, "PixelisedECALCollectionName",
 							"Pixelised ECAL Hits Collection",
 							_pECALColName,
+							// std::string("PixelSiEcalCollection"));
 							std::string("Not configured in xml file"));
 	registerInputCollection(LCIO::CALORIMETERHIT, "DigitisedECALCollectionName",
 							"Digitised ECAL Hits Collection",
 							_dECALColName,
+							// std::string("EcalCollection"));
 							std::string("Not configured in xml file"));
-    if (_MCColName!="Not configured in xml file") {_flagMcCol = true;}
-    if (_ECALColName!="Not configured in xml file") {_flagEcalCol = true;}
-    if (_pECALColName!="Not configured in xml file") {_flagPixelEcalCol = true;}
-    if (_dECALColName!="Not configured in xml file") {_flagDigitEcalCol = true;}
 }
 
 GetEnergyResolutionProcessor::~GetEnergyResolutionProcessor() {}
@@ -67,55 +67,64 @@ GetEnergyResolutionProcessor::~GetEnergyResolutionProcessor() {}
 void GetEnergyResolutionProcessor::init() {
 	AIDAProcessor::tree(this);
 	printParameters();
+    if (_MCColName!="Not configured in xml file") {_flagMcCol = true;}
+    if (_ECALColName!="Not configured in xml file") {_flagEcalCol = true;}
+    if (_pECALColName!="Not configured in xml file") {_flagPixelEcalCol = true;}
+    if (_dECALColName!="Not configured in xml file") {_flagDigitEcalCol = true;}
     // MC particle
-    _runEnergy = new TH1F("_runInfo", "Run Information", 1, 0, 1); // Bin 1: Beam energy
+    if (_flagMcCol) {
+        _runEnergy = new TH1F("_runInfo", "Run Information", 1, 0, 1); // Bin 1: Beam energy‘        
+    }
 
     // Monolithic calorimeter hits
-    _zMonoHist = new TH1D("mono_zHist","Z Distribution; z [layer]; Number of hit", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5);//Histogram of Z (Layer) distribution of hits
-    _evMonoEnergyHist = new TH1D("mono_evEnergyHist","Energy of shower Distribution; E_{dep} [GeV]", evHistBins, 0, evHistBins);
+    if (_flagEcalCol) {
+        _zMonoHist = new TH1D("mono_zHist","Z Distribution; z [layer]; Number of hit", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5);//Histogram of Z (Layer) distribution of hits
+        _evMonoEnergyHist = new TH1D("mono_evEnergyHist","Energy of shower Distribution; E_{dep} [GeV]", evHistBins, 0, evHistBins);
+        for (int i = 0; i < NUMBER_OF_LAYER; i++) {
+            _energyInMonoLayerSi[i] = new TH1F(Form("mono_energyInLayerSi_%d",i+1),"Energy deposited in monolithic layer; E_{dep} [GeV];",100, 0, 0.05);
+        }
+    }
 
     // Pixelised calorimeter hits
-    _xHist = new TH1D("pixel_xHist","X Distribution; x [cell]; Number of hit", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);//Histogram of X distribution of hits in ECAL pixel coordinates
-    _yHist = new TH1D("pixel_yHist","Y Distribution; y [cell]; Number of hit", NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);//Histogram of Y distribution of hits
-    _zHist = new TH1D("pixel_zHist","Z Distribution; z [layer]; Number of hit", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5);//Histogram of Z (Layer) distribution of hits
-    _xyHist = new TH2F("pixel_xyHist","XY view all events", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);
-    _zxHist = new TH2F("pixel_zxHist","ZX view all events", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5, NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);
-    _zyHist = new TH2F("pixel_zyHist","ZY view all events", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);
-    _cellEnergyHist = new TH1F("pixel_cellEnergyHist","Energy deposited in cells Distribution; E_{dep} [GeV]; Number of hit", 200, E_RANGE_MIN, E_RANGE_MAX);//Histogram of the energy deposition in all cell for all events
-    // The histogram will instead be declared and filled at the ending stage
-    // Bin ranges will be changed at the final stage
-    _evEnergyHist = new TH1D("pixel_evEnergyHist","Energy of shower Distribution; E_{dep} [GeV]", evHistBins, 0, evHistBins);
-    _evHitsHist = new TH1D("pixel_evHitsHist","Number of hits Distribution; Hit", evHistBins, 0, evHistBins);
-	
-    // Digitised calorimeter hits
-    _xDigitHist = new TH1D("digit_xHist","X Distribution; x [cell]; Number of hit", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);//Histogram of X distribution of hits in ECAL pixel coordinates
-    _yDigitHist = new TH1D("digit_yHist","Y Distribution; y [cell]; Number of hit", NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);//Histogram of Y distribution of hits
-    _zDigitHist = new TH1D("digit_zHist","Z Distribution; z [layer]; Number of hit", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5);//Histogram of Z (Layer) distribution of hits
-    _xyDigitHist = new TH2F("digit_xyHist","XY view all events", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);
-    _zxDigitHist = new TH2F("digit_zxHist","ZX view all events", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5, NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);
-    _zyDigitHist = new TH2F("digit_zyHist","ZY view all events", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);
-    _cellDigitEnergyHist = new TH1F("digit_cellEnergyHist","Energy deposited in cells Distribution; E_{dep} [GeV]; Number of hit", 200, E_RANGE_MIN, E_RANGE_MAX);//Histogram of the energy deposition in all cell for all events
-    // The histogram will instead be declared and filled at the ending stage
-    // Bin ranges will be changed at the final stage
-    _evDigitEnergyHist = new TH1D("digit_evEnergyHist","Energy of shower Distribution; E_{dep} [GeV]", evHistBins, 0, evHistBins);
-    _evDigitHitsHist = new TH1D("digit_evHitsHist","Number of hits Distribution; Hit", evHistBins, 0, evHistBins);
+    if (_flagPixelEcalCol) {
+        _xHist = new TH1D("pixel_xHist","X Distribution; x [cell]; Number of hit", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);//Histogram of X distribution of hits in ECAL pixel coordinates
+        _yHist = new TH1D("pixel_yHist","Y Distribution; y [cell]; Number of hit", NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);//Histogram of Y distribution of hits
+        _zHist = new TH1D("pixel_zHist","Z Distribution; z [layer]; Number of hit", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5);//Histogram of Z (Layer) distribution of hits
+        _xyHist = new TH2F("pixel_xyHist","XY view all events", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);
+        _zxHist = new TH2F("pixel_zxHist","ZX view all events", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5, NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);
+        _zyHist = new TH2F("pixel_zyHist","ZY view all events", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);
+        _cellEnergyHist = new TH1F("pixel_cellEnergyHist","Energy deposited in cells Distribution; E_{dep} [GeV]; Number of hit", 200, E_RANGE_MIN, E_RANGE_MAX);//Histogram of the energy deposition in all cell for all events
+        // The histogram will instead be declared and filled at the ending stage
+        // Bin ranges will be changed at the final stage
+        _evEnergyHist = new TH1D("pixel_evEnergyHist","Energy of shower Distribution; E_{dep} [GeV]", evHistBins, 0, evHistBins);
+        _evHitsHist = new TH1D("pixel_evHitsHist","Number of hits Distribution; Hit", evHistBins, 0, evHistBins);
+        for (int i = 0; i < NUMBER_OF_LAYER; i++) {
+            _energyInLayerSi[i] = new TH1F(Form("pixel_energyInLayerSi_%d",i+1),"Energy deposited in layer; E_{dep} [GeV];",100, 0, 0.05);
+            _energyInLayerSi[i]->SetTitle(Form("Total energy in layer %d",i+1));
+            _hitsInLayer[i] = new TH1F(Form("pixel_HitsInLayer_%d",i+1),"Hits in layer; Hit;",100, -0.5, 99.5);
+            _hitsInLayer[i]->SetTitle(Form("Total hits in layer %d",i+1));
+        }
+    }
 
-	
-    for (int i = 0; i < NUMBER_OF_LAYER; i++) {
-        // Monolithic calorimeter hits
-        _energyInMonoLayerSi[i] = new TH1F(Form("mono_energyInLayerSi_%d",i+1),"Energy deposited in monolithic layer; E_{dep} [GeV];",100, 0, 0.05);
-        
-        // Pixelised calorimeter hits
-        _energyInLayerSi[i] = new TH1F(Form("pixel_energyInLayerSi_%d",i+1),"Energy deposited in layer; E_{dep} [GeV];",100, 0, 0.05);
-        _energyInLayerSi[i]->SetTitle(Form("Total energy in layer %d",i+1));
-        _hitsInLayer[i] = new TH1F(Form("pixel_HitsInLayer_%d",i+1),"Hits in layer; Hit;",100, -0.5, 99.5);
-        _hitsInLayer[i]->SetTitle(Form("Total hits in layer %d",i+1));
-        
-        // Digitised calorimeter hits
-        _energyInDigitLayerSi[i] = new TH1F(Form("digit_energyInLayerSi_%d",i+1),"Energy deposited in layer; E_{dep} [GeV];",100, 0, 0.05);
-        _energyInDigitLayerSi[i]->SetTitle(Form("Total energy in layer %d",i+1));
-        _hitsInDigitLayer[i] = new TH1F(Form("digit_HitsInLayer_%d",i+1),"Hits in layer; Hit;",100, -0.5, 99.5);
-        _hitsInDigitLayer[i]->SetTitle(Form("Total hits in layer %d",i+1));
+    // Digitised calorimeter hits
+    if (_flagDigitEcalCol) {
+        _xDigitHist = new TH1D("digit_xHist","X Distribution; x [cell]; Number of hit", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);//Histogram of X distribution of hits in ECAL pixel coordinates
+        _yDigitHist = new TH1D("digit_yHist","Y Distribution; y [cell]; Number of hit", NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);//Histogram of Y distribution of hits
+        _zDigitHist = new TH1D("digit_zHist","Z Distribution; z [layer]; Number of hit", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5);//Histogram of Z (Layer) distribution of hits
+        _xyDigitHist = new TH2F("digit_xyHist","XY view all events", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);
+        _zxDigitHist = new TH2F("digit_zxHist","ZX view all events", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5, NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);
+        _zyDigitHist = new TH2F("digit_zyHist","ZY view all events", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);
+        _cellDigitEnergyHist = new TH1F("digit_cellEnergyHist","Energy deposited in cells Distribution; E_{dep} [GeV]; Number of hit", 200, E_RANGE_MIN, E_RANGE_MAX);//Histogram of the energy deposition in all cell for all events
+        // The histogram will instead be declared and filled at the ending stage
+        // Bin ranges will be changed at the final stage
+        _evDigitEnergyHist = new TH1D("digit_evEnergyHist","Energy of shower Distribution; E_{dep} [GeV]", evHistBins, 0, evHistBins);
+        _evDigitHitsHist = new TH1D("digit_evHitsHist","Number of hits Distribution; Hit", evHistBins, 0, evHistBins);
+        for (int i = 0; i < NUMBER_OF_LAYER; i++) {
+            _energyInDigitLayerSi[i] = new TH1F(Form("digit_energyInLayerSi_%d",i+1),"Energy deposited in layer; E_{dep} [GeV];",100, 0, 0.05);
+            _energyInDigitLayerSi[i]->SetTitle(Form("Total energy in layer %d",i+1));
+            _hitsInDigitLayer[i] = new TH1F(Form("digit_HitsInLayer_%d",i+1),"Hits in layer; Hit;",100, -0.5, 99.5);
+            _hitsInDigitLayer[i]->SetTitle(Form("Total hits in layer %d",i+1));
+        }
     }
 }
 
@@ -146,6 +155,7 @@ void GetEnergyResolutionProcessor::ShowMCInfo(EVENT::LCCollection *myCollection)
 
 void GetEnergyResolutionProcessor::ShowECALInfo(EVENT::LCCollection *myCollection) {
     int number = myCollection->getNumberOfElements();
+    streamlog_out(DEBUG) << "TOTAL NUMBER OF HITS: " << number <<endl;
     CellIDDecoder<EVENT::SimCalorimeterHit> cd(myCollection);
     
 	double totalEnergy = 0;
@@ -168,6 +178,7 @@ void GetEnergyResolutionProcessor::ShowECALInfo(EVENT::LCCollection *myCollectio
         streamlog_out(DEBUG) << " y = " << xyz_y <<" mm,";
         streamlog_out(DEBUG) << " z = " << xyz_z <<" layer,";
         streamlog_out(DEBUG) << " energy = " << hit_energy <<"GeV.\n";
+        totalEnergy += hit_energy;
         totalEnergyLayerSi[xyz_z] += hit_energy;
         hitsInLayer[xyz_z]++;
         _zMonoHist->Fill(xyz_z+1);
@@ -183,7 +194,7 @@ void GetEnergyResolutionProcessor::ShowECALInfo(EVENT::LCCollection *myCollectio
 
 void GetEnergyResolutionProcessor::ShowPixelECALInfo(EVENT::LCCollection *myCollection) {
     int number = myCollection->getNumberOfElements();
-    streamlog_out(MESSAGE) << "TOTAL NUMBER OF HITS: " << number <<endl;
+    streamlog_out(DEBUG) << "TOTAL NUMBER OF HITS: " << number <<endl;
     CellIDDecoder<EVENT::SimCalorimeterHit> cd(myCollection);
     
 	double totalEnergy = 0;
@@ -219,7 +230,7 @@ void GetEnergyResolutionProcessor::ShowPixelECALInfo(EVENT::LCCollection *myColl
 		_zxHist->Fill(IJK_K,IJK_I);
 		_zyHist->Fill(IJK_K,IJK_J);
     }
-    streamlog_out(MESSAGE) << "Total energy deposit: " << totalEnergy << " GeV" <<endl;
+    streamlog_out(DEBUG) << "Total energy deposit: " << totalEnergy << " GeV" <<endl;
     // Instead of filling the histograms now, we store the numbers in vectors first, then decide the binsize later
 	// _evEnergyHist->Fill(totalEnergy);
 	// _evHitsHist->Fill(totalHits);
@@ -235,9 +246,9 @@ void GetEnergyResolutionProcessor::ShowPixelECALInfo(EVENT::LCCollection *myColl
 
 void GetEnergyResolutionProcessor::ShowDigitECALInfo(EVENT::LCCollection *myCollection) {
     int number = myCollection->getNumberOfElements();
-    streamlog_out(MESSAGE) << "TOTAL NUMBER OF HITS: " << number <<endl;
-    CellIDDecoder<EVENT::SimCalorimeterHit> cd(myCollection);
-    
+    streamlog_out(DEBUG) << "TOTAL NUMBER OF HITS: " << number <<endl;
+    CellIDDecoder<EVENT::CalorimeterHit> cd(myCollection);
+
 	double totalEnergy = 0;
     int totalHits = 0;
 	double totalEnergyLayerSi[NUMBER_OF_LAYER];
@@ -246,14 +257,14 @@ void GetEnergyResolutionProcessor::ShowDigitECALInfo(EVENT::LCCollection *myColl
     std::fill(std::begin(hitsInLayer), std::end(hitsInLayer), 0);
     
     for (int i = 0; i < number; i++) {
-        SimCalorimeterHit *ecalhit = dynamic_cast<SimCalorimeterHit *>(myCollection->getElementAt(i));
+        CalorimeterHit *ecalhit = dynamic_cast<CalorimeterHit *>(myCollection->getElementAt(i));
         
         int IJK_I = cd(ecalhit)["I"];
         int IJK_J = cd(ecalhit)["J"];
         int IJK_K = cd(ecalhit)["K"];
         float hit_energy = ecalhit->getEnergy();
 
-        streamlog_out(DEBUG) << "\n SimCalorimeterHit, :" << i;
+        streamlog_out(DEBUG) << "\n CalorimeterHit, :" << i;
         streamlog_out(DEBUG) << " cellID-encoded=" << ecalhit->getCellID0();
         streamlog_out(DEBUG) << " I = " << IJK_I <<" mm,";
         streamlog_out(DEBUG) << " J = " << IJK_J <<" mm,";
@@ -271,7 +282,7 @@ void GetEnergyResolutionProcessor::ShowDigitECALInfo(EVENT::LCCollection *myColl
 		_zxDigitHist->Fill(IJK_K,IJK_I);
 		_zyDigitHist->Fill(IJK_K,IJK_J);
     }
-    streamlog_out(MESSAGE) << "Total energy deposit: " << totalEnergy << " GeV" <<endl;
+    streamlog_out(DEBUG) << "Total energy deposit: " << totalEnergy << " GeV" <<endl;
     // Instead of filling the histograms now, we store the numbers in vectors first, then decide the binsize later
 	// _evEnergyHist->Fill(totalEnergy);
 	// _evHitsHist->Fill(totalHits);
@@ -293,14 +304,14 @@ void GetEnergyResolutionProcessor::processRunHeader(LCRunHeader *run)
 
 void GetEnergyResolutionProcessor::processEvent(LCEvent *evt) {
     try {
-        streamlog_out(MESSAGE) << "\n ----------------------------------------- ";
+        streamlog_out(DEBUG) << "\n ----------------------------------------- ";
         if (_flagMcCol) {
             LCCollection *mccol = evt->getCollection(_MCColName);
             ShowMCInfo(mccol);
         }
         if (_flagEcalCol) {
             LCCollection *ecal = evt->getCollection(_ECALColName);
-            ShowPixelECALInfo(ecal);
+            ShowECALInfo(ecal);
         }
         if (_flagPixelEcalCol) {
             LCCollection *pecal = evt->getCollection(_pECALColName);
@@ -308,7 +319,7 @@ void GetEnergyResolutionProcessor::processEvent(LCEvent *evt) {
         }
         if (_flagDigitEcalCol) {
             LCCollection *decal = evt->getCollection(_dECALColName);
-            ShowPixelECALInfo(decal);
+            ShowDigitECALInfo(decal);
         }
     } catch (DataNotAvailableException &e) {
         streamlog_out(DEBUG) << "Whoops!....\n";
@@ -322,18 +333,20 @@ void GetEnergyResolutionProcessor::check(LCEvent * evt)
 }
 
 void GetEnergyResolutionProcessor::end() {
+    streamlog_out(MESSAGE) << "Event loop finished. Starting the fit..." <<endl;
     if (_flagMcCol) {
         _runEnergy->SetBinContent(1, runEnergy);
     }
-    
     if (_flagEcalCol) {
         // Using the full statistical information to determine the binsize
+        
         float meanMonoEnergy = TMath::Mean(_evMonoEnergyVec.begin(), _evMonoEnergyVec.end());
         float sigmaMonoEnergy = TMath::RMS(_evMonoEnergyVec.begin(), _evMonoEnergyVec.end());
         // Now declaring the histograms
         float minMonoEnergy = meanMonoEnergy - radiusOverSigma*sigmaMonoEnergy;
         float maxMonoEnergy = meanMonoEnergy + radiusOverSigma*sigmaMonoEnergy;
         _evMonoEnergyHist->SetBins(evHistBins, minMonoEnergy, maxMonoEnergy);
+        streamlog_out(DEBUG) << _evMonoEnergyVec.size() <<"\t"<< minMonoEnergy <<","<< maxMonoEnergy <<endl;
         // Now filling the histograms
         for (double energy:_evMonoEnergyVec) {_evMonoEnergyHist->Fill(energy);}
 
@@ -341,7 +354,7 @@ void GetEnergyResolutionProcessor::end() {
         _evMonoEnergyHist->Fit("gaus");
         TF1 *mono_fit = (TF1*) _evMonoEnergyHist->GetListOfFunctions()->FindObject("gaus");
         gStyle->SetOptFit(1111);
-        streamlog_out(MESSAGE) << "\n Mono Fit " << mono_fit->GetParameter(2) <<endl;
+        streamlog_out(MESSAGE) << "\n Mono Fit Res. " << mono_fit->GetParameter(2) / mono_fit->GetParameter(1) <<endl;
     }
     
     if (_flagPixelEcalCol) {
@@ -357,6 +370,7 @@ void GetEnergyResolutionProcessor::end() {
         float maxHits = meanHits + radiusOverSigma*sigmaHits;
         _evEnergyHist->SetBins(evHistBins, minEnergy, maxEnergy);
         _evHitsHist->SetBins(evHistBins, minHits, maxHits);
+        streamlog_out(DEBUG) << _evEnergyVec.size() <<"\t"<< minEnergy <<","<< maxEnergy <<endl;
         // Now filling the histograms
         for (double energy:_evEnergyVec) {_evEnergyHist->Fill(energy);}
         for (int hits:_evHitsVec) {_evHitsHist->Fill(hits);}
@@ -372,7 +386,7 @@ void GetEnergyResolutionProcessor::end() {
         TF1 *fit = (TF1*)_evEnergyHist->GetListOfFunctions()->FindObject("gaus");
         gStyle->SetOptFit(1111);//Set to 1 to show and save the fit with the histogram in the root file generated by the AIDAProcessor
 
-        streamlog_out(MESSAGE) << "\n Pixel Fit " << fit->GetParameter(2) <<endl;
+        streamlog_out(MESSAGE) << "\n Pixel Fit Res. " << fit->GetParameter(2) / fit->GetParameter(1) <<endl;
 
         // Doing the fitting layer-by-layer seems unnecessary,
         // as the eventual Gaussian distribution comes from the large number of Laudau sampling.
@@ -393,10 +407,10 @@ void GetEnergyResolutionProcessor::end() {
 
     if (_flagDigitEcalCol) {
         // Using the full statistical information to determine the binsize
-        float meanDigitEnergy = TMath::Mean(_evEnergyVec.begin(), _evEnergyVec.end());
-        float sigmaDigitEnergy = TMath::RMS(_evEnergyVec.begin(), _evEnergyVec.end());
-        float meanDigitHits = TMath::Mean(_evHitsVec.begin(), _evHitsVec.end());
-        float sigmaDigitHits = TMath::RMS(_evHitsVec.begin(), _evHitsVec.end());
+        float meanDigitEnergy = TMath::Mean(_evDigitEnergyVec.begin(), _evDigitEnergyVec.end());
+        float sigmaDigitEnergy = TMath::RMS(_evDigitEnergyVec.begin(), _evDigitEnergyVec.end());
+        float meanDigitHits = TMath::Mean(_evDigitHitsVec.begin(), _evDigitHitsVec.end());
+        float sigmaDigitHits = TMath::RMS(_evDigitHitsVec.begin(), _evDigitHitsVec.end());
         // Now declaring the histograms
         float minDigitEnergy = meanDigitEnergy - radiusOverSigma*sigmaDigitEnergy;
         float maxDigitEnergy = meanDigitEnergy + radiusOverSigma*sigmaDigitEnergy;
@@ -404,6 +418,7 @@ void GetEnergyResolutionProcessor::end() {
         float maxDigitHits = meanDigitHits + radiusOverSigma*sigmaDigitHits;
         _evDigitEnergyHist->SetBins(evHistBins, minDigitEnergy, maxDigitEnergy);
         _evDigitHitsHist->SetBins(evHistBins, minDigitHits, maxDigitHits);
+        streamlog_out(MESSAGE) << _evDigitEnergyVec.size() <<"\t"<< minDigitEnergy <<","<< maxDigitEnergy <<endl;
         // Now filling the histograms
         for (double energy:_evDigitEnergyVec) {_evDigitEnergyHist->Fill(energy);}
         for (int hits:_evDigitHitsVec) {_evDigitHitsHist->Fill(hits);}
@@ -416,7 +431,7 @@ void GetEnergyResolutionProcessor::end() {
         TF1 *digit_fit = (TF1*)_evDigitEnergyHist->GetListOfFunctions()->FindObject("gaus");
         gStyle->SetOptFit(1111);//Set to 1 to show and save the fit with the histogram in the root file generated by the AIDAProcessor
 
-        streamlog_out(MESSAGE) << "\n Digit Fit " << digit_fit->GetParameter(2) <<endl;
+        streamlog_out(MESSAGE) << "\n Digit Fit Res. " << digit_fit->GetParameter(2) / digit_fit->GetParameter(1) <<endl;
     }
     streamlog_out(MESSAGE) << "Fitting done\nPlotting results..." <<endl;
 }

--- a/GetEnergyResolution/src/GetEnergyResolutionProcessor.cc
+++ b/GetEnergyResolution/src/GetEnergyResolutionProcessor.cc
@@ -114,13 +114,13 @@ void GetEnergyResolutionProcessor::init() {
         _xyDigitHist = new TH2F("digit_xyHist","XY view all events", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);
         _zxDigitHist = new TH2F("digit_zxHist","ZX view all events", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5, NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);
         _zyDigitHist = new TH2F("digit_zyHist","ZY view all events", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);
-        _cellDigitEnergyHist = new TH1F("digit_cellEnergyHist","Energy deposited in cells Distribution; E_{dep} [GeV]; Number of hit", 200, E_RANGE_MIN, E_RANGE_MAX);//Histogram of the energy deposition in all cell for all events
+        _cellDigitEnergyHist = new TH1F("digit_cellEnergyHist","Energy deposited in cells Distribution; E_{dep} [MIP]; Number of hit", 200, E_RANGE_MIN, E_RANGE_MAX);//Histogram of the energy deposition in all cell for all events
         // The histogram will instead be declared and filled at the ending stage
         // Bin ranges will be changed at the final stage
-        _evDigitEnergyHist = new TH1D("digit_evEnergyHist","Energy of shower Distribution; E_{dep} [GeV]", evHistBins, 0, evHistBins);
+        _evDigitEnergyHist = new TH1D("digit_evEnergyHist","Energy of shower Distribution; E_{dep} [MIP]", evHistBins, 0, evHistBins);
         _evDigitHitsHist = new TH1D("digit_evHitsHist","Number of hits Distribution; Hit", evHistBins, 0, evHistBins);
         for (int i = 0; i < NUMBER_OF_LAYER; i++) {
-            _energyInDigitLayerSi[i] = new TH1F(Form("digit_energyInLayerSi_%d",i+1),"Energy deposited in layer; E_{dep} [GeV];",100, 0, 0.05);
+            _energyInDigitLayerSi[i] = new TH1F(Form("digit_energyInLayerSi_%d",i+1),"Energy deposited in layer; E_{dep} [MIP];",100, 0, 0.05);
             _energyInDigitLayerSi[i]->SetTitle(Form("Total energy in layer %d",i+1));
             _hitsInDigitLayer[i] = new TH1F(Form("digit_HitsInLayer_%d",i+1),"Hits in layer; Hit;",100, -0.5, 99.5);
             _hitsInDigitLayer[i]->SetTitle(Form("Total hits in layer %d",i+1));

--- a/GetMIP/include/GetMIPProcessor.hh
+++ b/GetMIP/include/GetMIPProcessor.hh
@@ -46,6 +46,10 @@ using namespace marlin;
 
 class GetMIPProcessor : public Processor
 {
+private:
+    int NUMBER_OF_LAYER = 15;
+    int NUMBER_OF_CELLX = 64;
+    int NUMBER_OF_CELLY = 32;
 
 public:
   virtual Processor *newProcessor() { return new GetMIPProcessor; }
@@ -76,16 +80,19 @@ public:
   TH1* _zHist;
   TH2* _xyHist;
   TH1* _cellEnergyHist;
-  TH1F* _energyInLayerSi[15];
-  double _layerFitParams[15][4] = {0};
-//private:
+  TH1F* _energyInLayerSi[NUMBER_OF_LAYER];
+  TH1F* _energyInPixelLayerSi[NUMBER_OF_LAYER];
+  double _layerFitParams[NUMBER_OF_LAYER][4];
+  double _pixelLayerFitParams[NUMBER_OF_LAYER][4];
 
+private:
   virtual void ShowMCInfo(LCCollection *col);
   virtual void ShowECALInfo(LCCollection *col);
+    virtual void ShowPixelECALInfo(LCCollection *col);
 
   std::string _MCColName;
   std::string _ECALColName;
-
+    std::string _pECALColName;
 
 };
 

--- a/GetMIP/include/GetMIPProcessor.hh
+++ b/GetMIP/include/GetMIPProcessor.hh
@@ -22,6 +22,11 @@
 #include <vector>
 #include <array>
 
+// ----- include for verbosity dependent logging ---------
+#include "marlin/VerbosityLevels.h"
+#include "marlin/StringParameters.h"
+#define SLM streamlog_out(MESSAGE)
+
 #include "TH1.h"
 #include "TH2.h"
 #include "TH3.h"
@@ -43,13 +48,19 @@
 
 using namespace lcio;
 using namespace marlin;
+using namespace std;
 
 class GetMIPProcessor : public Processor
 {
 private:
-    int NUMBER_OF_LAYER = 15;
-    int NUMBER_OF_CELLX = 64;
-    int NUMBER_OF_CELLY = 32;
+    const static int NUMBER_OF_LAYER = 15;
+    const static int NUMBER_OF_CELLX = 64;
+    const static int NUMBER_OF_CELLY = 32;
+    float FIT_INIT_AMP = 5000;//events
+    float FIT_INIT_MPV = 0.1e-3;//GeV
+    float FIT_INIT_SIG = 0.01e-3;//GeV
+    float FIT_RANGE_MIN = 0;
+    float FIT_RANGE_MAX = 1e-3;//GeV
 
 public:
   virtual Processor *newProcessor() { return new GetMIPProcessor; }
@@ -80,10 +91,14 @@ public:
   TH1* _zHist;
   TH2* _xyHist;
   TH1* _cellEnergyHist;
-  TH1F* _energyInLayerSi[NUMBER_OF_LAYER];
-  TH1F* _energyInPixelLayerSi[NUMBER_OF_LAYER];
-  double _layerFitParams[NUMBER_OF_LAYER][4];
-  double _pixelLayerFitParams[NUMBER_OF_LAYER][4];
+    TH1F* _energyInLayerSi[NUMBER_OF_LAYER];
+    TH1F* _energyInPixelLayerSi[NUMBER_OF_LAYER];
+    double _layerFitParams[NUMBER_OF_LAYER][3];
+    double _pixelLayerFitParams[NUMBER_OF_LAYER][3];
+  
+    TF1* landauFunc = new TF1("fitLandauFunc", "landau", FIT_RANGE_MIN, FIT_RANGE_MAX);
+    TH1* _fittedMIP;
+    TH1* _fittedPixelMIP;
 
 private:
   virtual void ShowMCInfo(LCCollection *col);

--- a/GetMIP/scripts/test.xml
+++ b/GetMIP/scripts/test.xml
@@ -42,8 +42,9 @@
   </processor>
 
   <processor name="MyGetMIPProcessor" type="GetMIPProcessor">  
-    <parameter name="ECALCollectionName" type="string"> PixelSiEcalCollection </parameter>
     <parameter name="MCCollectionName" type="string"> MCParticle </parameter>
+    <parameter name="ECALCollectionName" type="string"> SiEcalCollection </parameter>
+    <parameter name="PixelisedECALCollectionName" type="string"> PixelSiEcalCollection </parameter>
   </processor>
 
 

--- a/GetMIP/src/GetMIPProcessor.cc
+++ b/GetMIP/src/GetMIPProcessor.cc
@@ -61,9 +61,9 @@ void GetMIPProcessor::init()
 {
 	printParameters();
 	AIDAProcessor::tree(this);//Using the AIDAProcessor to save the histograms created in init() in a root file
-    _xHist = new TH1D("xHist","X Distribution", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);//Histogram of X distribution of hits in ECAL pixel coordinates
-    _yHist = new TH1D("yHist","Y Distribution", NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);//Histogram of Y distribution of hits
-    _zHist = new TH1D("zHist","Z Distribution", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5);//Histogram of Z (Layer) distribution of hits
+    _xHist = new TH1D("xHist","X Distribution; x [cell]; Number of hit", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);//Histogram of X distribution of hits in ECAL pixel coordinates
+    _yHist = new TH1D("yHist","Y Distribution; y [cell]; Number of hit", NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);//Histogram of Y distribution of hits
+    _zHist = new TH1D("zHist","Z Distribution; z [layer]; Number of hit", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5);//Histogram of Z (Layer) distribution of hits
     _cellEnergyHist = new TH1F("cellEnergyHist","Energy deposited in cells Distribution", 200, FIT_RANGE_MIN, FIT_RANGE_MAX);//Histogram of the energy deposition in all cell for all events
 	
     _xyHist = new TH2D("xyHist","XY view all events", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);//Front view of the ECAL, XY distribution of hits
@@ -144,7 +144,7 @@ void GetMIPProcessor::ShowPixelECALInfo(EVENT::LCCollection *myCollection) {
     float totalEnergyLayerSi[NUMBER_OF_LAYER];
     int hitsInLayer[NUMBER_OF_LAYER];
     std::fill(std::begin(totalEnergyLayerSi), std::end(totalEnergyLayerSi), 0.0);
-    std::fill(std::begin(hitsInLayer), std::end(hitsInLayer), 0.0);
+    std::fill(std::begin(hitsInLayer), std::end(hitsInLayer), 0);
 
     for (int i = 0; i < number; i++) {
         SimCalorimeterHit *ecalhit = dynamic_cast<SimCalorimeterHit *>(myCollection->getElementAt(i));

--- a/GetMIP/src/GetMIPProcessor.cc
+++ b/GetMIP/src/GetMIPProcessor.cc
@@ -41,15 +41,15 @@ GetMIPProcessor::GetMIPProcessor() : Processor("GetMIPProcessor")
 	_description = "";
 
 	// input collections
-	registerInputCollection(LCIO::MCPARTICLE, "MCParticle",
-							"Muon MC collection",
+	registerInputCollection(LCIO::MCPARTICLE, "MCCollectionName",
+							"Primary Particle MC collection",
 							_MCColName,
 							std::string("MCParticle"));
-    registerInputCollection(LCIO::SIMCALORIMETERHIT, "SiEcalCollection",
+    registerInputCollection(LCIO::SIMCALORIMETERHIT, "ECALCollectionName",
                             "Sim ECAL Monolithic Collection",
                             _ECALColName,
                             std::string("SiEcalCollection"));
-	registerInputCollection(LCIO::SIMCALORIMETERHIT, "PixelSiEcalCollection",
+	registerInputCollection(LCIO::SIMCALORIMETERHIT, "PixelisedECALCollectionName",
                             "Sim ECAL Pixelised Collection",
                             _pECALColName,
 							std::string("PixelSiEcalCollection"));//Name of collection after using the Pixelization Processor, giving coordinates of hit in I,J,K starting from 1

--- a/GetMIP/src/GetMIPProcessor.cc
+++ b/GetMIP/src/GetMIPProcessor.cc
@@ -1,5 +1,5 @@
 #include "GetMIPProcessor.hh"
-#include "langaus.C"
+// #include "langaus.C"
 
 // ROOT
 #include "TStyle.h"
@@ -41,14 +41,17 @@ GetMIPProcessor::GetMIPProcessor() : Processor("GetMIPProcessor")
 	_description = "";
 
 	// input collections
-	registerInputCollection(LCIO::MCPARTICLE,"MCCollectionName",
-				"Name of the MC collection",
+	registerInputCollection(LCIO::MCPARTICLE, "MCParticle",
+							"Muon MC collection",
 							_MCColName,
-							std::string("MCParticles"));
-	registerInputCollection(LCIO::SIMCALORIMETERHIT,
-							"ECALCollection",
-							"Name of the Sim ECAL Collection",
-							_ECALColName,
+							std::string("MCParticle"));
+    registerInputCollection(LCIO::SIMCALORIMETERHIT, "SiEcalCollection",
+                            "Sim ECAL Monolithic Collection",
+                            _ECALColName,
+                            std::string("SiEcalCollection"));
+	registerInputCollection(LCIO::SIMCALORIMETERHIT, "PixelSiEcalCollection",
+                            "Sim ECAL Pixelised Collection",
+                            _pECALColName,
 							std::string("PixelSiEcalCollection"));//Name of collection after using the Pixelization Processor, giving coordinates of hit in I,J,K starting from 1
 }
 
@@ -58,15 +61,15 @@ void GetMIPProcessor::init()
 {
 	printParameters();
 	AIDAProcessor::tree(this);//Using the AIDAProcessor to save the histograms created in init() in a root file
-	_xHist = new TH1D("_xHist","X Distribution",64, 0.5, 64.5);//Histogram of X distribution of hits in ECAL pixel coordinates
-	_yHist = new TH1D("_yHist","Y Distribution",32, 0.5, 32.5);//Histogram of Y distribution of hits
-	_zHist = new TH1D("_zHist","Z Distribution",15, 0.5, 15.5);//Histogram of Z (Layer) distribution of hits
+    _xHist = new TH1D("_xHist","X Distribution", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5);//Histogram of X distribution of hits in ECAL pixel coordinates
+    _yHist = new TH1D("_yHist","Y Distribution", NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);//Histogram of Y distribution of hits
+    _zHist = new TH1D("_zHist","Z Distribution", NUMBER_OF_LAYER, 0.5, NUMBER_OF_LAYER +.5);//Histogram of Z (Layer) distribution of hits
 	_cellEnergyHist = new TH1F("_cellEnergyHist","Energy deposited in cells Distribution",200, 0, 0.002);//Histogram of the energy deposition in all cell for all events
 	
-	_xyHist = new TH2D("_xyHist","XY view all events",64,0.5,64.5,32, 0.5, 32.5);//Front view of the ECAL, XY distribution of hits
+    _xyHist = new TH2D("_xyHist","XY view all events", NUMBER_OF_CELLX, 0.5, NUMBER_OF_CELLX +.5, NUMBER_OF_CELLY, 0.5, NUMBER_OF_CELLY +.5);//Front view of the ECAL, XY distribution of hits
 	
 
-	for (int i = 0; i < 15; i++)
+    for (int i = 0; i < NUMBER_OF_LAYER; i++)
 	{
 		_energyInLayerSi[i] = new TH1F(Form("_energyInLayerSi_%d",i+1),"Energy deposited in layer ",200, 0, 0.002);//Histogram for the energy deposited in a layer for each event
 		_energyInLayerSi[i]->SetTitle(Form("Total energy in layer %d",i+1));
@@ -75,144 +78,156 @@ void GetMIPProcessor::init()
 }
 
 
-void GetMIPProcessor::ShowMCInfo(EVENT::LCCollection *myCollection)
-{
-  int number = myCollection->getNumberOfElements();
+void GetMIPProcessor::ShowMCInfo(EVENT::LCCollection *myCollection) {
+    int number = myCollection->getNumberOfElements();
   
-    for (int i = 0; i < number; i++)//Loop through the MC Particle collection for one event
-    {
-
-      MCParticle *particle = dynamic_cast<MCParticle *>(myCollection->getElementAt(i));
-      vector<MCParticle *> daughters = particle->getDaughters();
-
-      streamlog_out(MESSAGE) << "\n MCCollection, particle:"  ;
-      streamlog_out(MESSAGE) << " pdg=" << particle->getPDG();
-      streamlog_out(MESSAGE) << " satus=" << particle->getGeneratorStatus();
-      streamlog_out(MESSAGE) << " Ndaughters=" << daughters.size();
-      streamlog_out(MESSAGE) << " E=" << particle->getEnergy();
-      streamlog_out(MESSAGE) << " px=" << particle->getMomentum()[0];
-      streamlog_out(MESSAGE) << " py=" << particle->getMomentum()[1];
-      streamlog_out(MESSAGE) << " pz=" << particle->getMomentum()[2];
-      streamlog_out(MESSAGE) << " m=" << particle->getMass();
-      streamlog_out(MESSAGE) << " charge=" << particle->getCharge();
-
+    for (int i = 0; i < number; i++) {//Loop through the MC Particle collection for one event
+        MCParticle *particle = dynamic_cast<MCParticle *>(myCollection->getElementAt(i));
+        vector<MCParticle *> daughters = particle->getDaughters();
+    
+        streamlog_out(MESSAGE) << "\n MCCollection, particle:" << i;
+        streamlog_out(MESSAGE) << " pdg = " << particle->getPDG() <<",";
+        streamlog_out(MESSAGE) << " status = " << particle->getGeneratorStatus() <<",";
+        streamlog_out(MESSAGE) << " N_daughters = " << daughters.size() <<",";
+        streamlog_out(MESSAGE) << " E = " << particle->getEnergy() <<" GeV,";
+        streamlog_out(MESSAGE) << " px = " << particle->getMomentum()[0] <<" GeV,";
+        streamlog_out(MESSAGE) << " py = " << particle->getMomentum()[1] <<" GeV,";
+        streamlog_out(MESSAGE) << " pz = " << particle->getMomentum()[2] <<" GeV,";
+        streamlog_out(MESSAGE) << " m = " << particle->getMass() <<" GeV,";
+        streamlog_out(MESSAGE) << " charge = " << particle->getCharge() <<".";
     }
-  	//streamlog_out(MESSAGE) << "this treeed" << std::endl;
-
+  	streamlog_out(MESSAGE) << std::endl;
 }
 
- void GetMIPProcessor::ShowECALInfo(EVENT::LCCollection *myCollection)
-{
-  int number = myCollection->getNumberOfElements();
-  CellIDDecoder<EVENT::SimCalorimeterHit> cd(myCollection);
+void GetMIPProcessor::ShowECALInfo(EVENT::LCCollection *myCollection) {
+    int number = myCollection->getNumberOfElements();
+    CellIDDecoder<EVENT::SimCalorimeterHit> cd(myCollection);
+    
+    float totalEnergyLayerSi[NUMBER_OF_LAYER];
+    int hitsInLayer[NUMBER_OF_LAYER];
+    std::fill(std::start(totalEnergyLayerSi), std::end(totalEnergyLayerSi), 0.0)
+    std::fill(std::start(hitsInLayer), std::end(hitsInLayer), 0.0)
 
-	double totalEnergyLayerSi[15] = {0};
-	int hitsInLayer[15] = {0};
-  for (int i = 0; i < number; i++)//Loop through the ECAL Hits in one event (after pixelization)
-    {
+    for (int i = 0; i < number; i++) {
+        SimCalorimeterHit *ecalhit = dynamic_cast<SimCalorimeterHit *>(myCollection->getElementAt(i));
 
-      SimCalorimeterHit *ecalhit = dynamic_cast<SimCalorimeterHit *>(myCollection->getElementAt(i));
-		int x_in_IJK_coordinates = cd(ecalhit)["I"];//Reading the x, y and layer coordinate of one hit in the collection
-    	int y_in_IJK_coordinates = cd(ecalhit)["J"];
-        int z_in_IJK_coordinates = cd(ecalhit)["K"];
-		//_coordinateZ=z_in_IJK_coordinates;
- /*     streamlog_out(MESSAGE) << "\n SimCalorimeterHit, :" << i;
-      streamlog_out(MESSAGE) << " cellID-encoded=" << ecalhit->getCellID0();
-      streamlog_out(MESSAGE) << " x_in_IJK_coordinates=" << x_in_IJK_coordinates;
-      streamlog_out(MESSAGE) << " y_in_IJK_coordinates=" << y_in_IJK_coordinates;
-      streamlog_out(MESSAGE) << " z_in_IJK_coordinates=" << z_in_IJK_coordinates;
-      streamlog_out(MESSAGE) << " energy=" << ecalhit->getEnergy();
-      streamlog_out(MESSAGE) << " NUMBER=" << number;
-*/		
-		
-		totalEnergyLayerSi[z_in_IJK_coordinates-1]=totalEnergyLayerSi[z_in_IJK_coordinates-1]+ecalhit->getEnergy();//Adding the energy of the event separated by layers
-		hitsInLayer[z_in_IJK_coordinates-1]++;//Counting the hits per layer in one event
-		_xHist->Fill(x_in_IJK_coordinates);//Fill the x, y, z and energy distribution histograms
-		_yHist->Fill(y_in_IJK_coordinates);
-		_zHist->Fill(z_in_IJK_coordinates);
-		_cellEnergyHist->Fill(ecalhit->getEnergy());
-		_xyHist->Fill(x_in_IJK_coordinates,y_in_IJK_coordinates);
+        int xyz_x = cd(ecalhit)["x"];
+        int xyz_y = cd(ecalhit)["y"];
+        int xyz_z = cd(ecalhit)["layer"];
+        float hit_energy = ecalhit->getEnergy()
 
+        streamlog_out(MESSAGE) << "\n SimCalorimeterHit, :" << i;
+        streamlog_out(MESSAGE) << " cellID-encoded=" << ecalhit->getCellID0();
+        // streamlog_out(MESSAGE) << " x = " << xyz_x <<" mm,";
+        // streamlog_out(MESSAGE) << " y = " << xyz_y <<" mm,";
+        streamlog_out(MESSAGE) << " z = " << xyz_z <<" layer,";
+        streamlog_out(MESSAGE) << " energy = " << hit_energy <<"GeV.\n";
+        totalEnergyLayerSi[xyz_z] += hit_energy;
     }
-
-
-	for (int i = 0; i < 15; i++)
-	{
-		if (hitsInLayer[i]==1)//Filling energy in layer histograms only with events with one hit per layer (muon) to calculate the MIP
-		{
-			_energyInLayerSi[i]->Fill(totalEnergyLayerSi[i]);
-			totalEnergyLayerSi[i]=0;
-		}
-		
+    // return totalEnergyLayerSi;
+    for (int i = 0; i < NUMBER_OF_LAYER; i++) {
+        if (hitsInLayer[i]==1) {//Filling energy in layer histograms only with events with one hit per layer (muon) to calculate the MIP
+            _energyInLayerSi[i]->Fill(totalEnergyLayerSi[i]);
+        }
 	}
+}//By this point all histograms are filled for one event, this is repeated for all the events in the collection
 
-	
+void GetMIPProcessor::ShowPixelECALInfo(EVENT::LCCollection *myCollection) {
+    int number = myCollection->getNumberOfElements();
+    CellIDDecoder<EVENT::SimCalorimeterHit> cd(myCollection);
 
+    float totalEnergyLayerSi[NUMBER_OF_LAYER];
+    std::fill(std::start(totalEnergyLayerSi), std::end(totalEnergyLayerSi), 0.0)
+
+    for (int i = 0; i < number; i++) {
+        SimCalorimeterHit *ecalhit = dynamic_cast<SimCalorimeterHit *>(myCollection->getElementAt(i));
+
+        int IJK_I = cd(ecalhit)["I"];
+        int IJK_J = cd(ecalhit)["J"];
+        int IJK_K = cd(ecalhit)["K"];
+        float hit_energy = ecalhit->getEnergy()
+
+        // streamlog_out(MESSAGE) << "\n SimCalorimeterHit, :" << i;
+        // streamlog_out(MESSAGE) << " cellID-encoded=" << ecalhit->getCellID0();
+        // streamlog_out(MESSAGE) << " I = " << IJK_I <<" mm,";
+        // streamlog_out(MESSAGE) << " J = " << IJK_J <<" mm,";
+        // streamlog_out(MESSAGE) << " K = " << IJK_K <<" layer,";
+        // streamlog_out(MESSAGE) << " energy = " << hit_energy <<" GeV.\n";
+        totalEnergyLayerSi[IJK_K-1] += hit_energy;
+        _xHist->Fill(IJK_I);//Fill the x, y, z and energy distribution histograms
+        _yHist->Fill(IJK_J);
+        _zHist->Fill(IJK_K);
+        _cellEnergyHist->Fill(ecalhit->getEnergy());
+        _xyHist->Fill(IJK_I, IJK_J);
+    }
+    // return totalEnergyLayerSi;
+    for (int i = 0; i < NUMBER_OF_LAYER; i++) {
+        if (hitsInLayer[i]==1) {//Filling energy in layer histograms only with events with one hit per layer (muon) to calculate the MIP
+            _energyInPixelLayerSi[i]->Fill(totalEnergyLayerSi[i]);
+        }
+	}
 }//By this point all histograms are filled for one event, this is repeated for all the events in the collection
 
 
-void GetMIPProcessor::processRunHeader(LCRunHeader *run)
-{
+void GetMIPProcessor::processRunHeader(LCRunHeader *run) {
 }
 
 void GetMIPProcessor::processEvent(LCEvent *evt)
 {
 
-	try
-	  {
+	try {
 	    streamlog_out(MESSAGE) << "\n ----------------------------------------- ";
 	    LCCollection *mccol = evt->getCollection(_MCColName);
 	    ShowMCInfo(mccol);
-	    
 	    LCCollection *ecal = evt->getCollection(_ECALColName);
 	    ShowECALInfo(ecal);
-
-	
-	}catch (DataNotAvailableException &e)
-	{
+	    LCCollection *pecal = evt->getCollection(_pECALColName);
+	    ShowPixelECALInfo(pecal);
+    } catch (DataNotAvailableException &e) {
 		streamlog_out(DEBUG) << "Whoops!....\n";
 		streamlog_out(DEBUG) << e.what();
 	}
 
 }
 
-	void GetMIPProcessor::check(LCEvent * evt)
-	{
-		// nothing to check here - could be used to fill checkplots in reconstruction processor
-	}
+void GetMIPProcessor::check(LCEvent * evt) {
+    // nothing to check here - could be used to fill checkplots in reconstruction processor
+}
 
-	void GetMIPProcessor::end()//Using this function to fit the energy in layer histograms after all the events have been processed 
-	{
-		std::vector<float> MIP;
-		for (int i = 0; i < 15; i++)//For each layer
-		{
-				// Fitting SNR histo
-			printf("Fitting...\n");
-			
-			_energyInLayerSi[i]->Fit("landau");	//Fit a landau to the distribution
-			TF1 *fit = (TF1*)_energyInLayerSi[i]->GetListOfFunctions()->FindObject("landau");
-			gStyle->SetOptFit(1111);//Set to 1 to show and save the fit with the histogram in the root file generated by the AIDAProcessor
-			printf("Fitting done\nPlotting results...\n");
-			for (int j = 0; j < 3; j++)//Save all fit parameters in the array
-			{
-				_layerFitParams[i][j] = fit->GetParameter(j);
-			}
-			
-		}
-		for (int j = 0; j < 15; j++)
-		{
-			streamlog_out(MESSAGE) << "\n Fit PARAMS for layer " << j;//Printing all fit parameters for each layer
-			for (int h = 0; h < 3; h++)
-			{
-				streamlog_out(MESSAGE) << "\n par["<< h <<"] = "<< _layerFitParams[j][h];
-			}
-				MIP.push_back(_layerFitParams[j][1]);
-		}	
-    std::cout << '\n';
-	
-	// Print out the vector
-    for (float n : MIP)
-        std::cout << n << ' ';
+void GetMIPProcessor::end() {//Using this function to fit the energy in layer histograms after all the events have been processed 
+    std::vector<float> MIP;
+    for (int i = 0; i < NUMBER_OF_LAYER; i++) {//For each layer
+        // Fitting SNR histo
+        printf("Fitting...\n");
+        
+        _energyInLayerSi[i]->Fit("landau");	//Fit a landau to the distribution
+        TF1 *fit = (TF1*)_energyInLayerSi[i]->GetListOfFunctions()->FindObject("landau");
+        gStyle->SetOptFit(1111);//Set to 1 to show and save the fit with the histogram in the root file generated by the AIDAProcessor
+        printf("Fitting done\nPlotting results...\n");
+        for (int j = 0; j < 3; j++) {//Save all fit parameters in the array
+            _layerFitParams[i][j] = fit->GetParameter(j);
+        }
+
+        _energyInPixelLayerSi[i]->Fit("landau");	//Fit a landau to the distribution
+        TF1 *fit = (TF1*)_energyInPixelLayerSi[i]->GetListOfFunctions()->FindObject("landau");
+        gStyle->SetOptFit(1111);//Set to 1 to show and save the fit with the histogram in the root file generated by the AIDAProcessor
+        printf("Fitting done\nPlotting results...\n");
+        for (int j = 0; j < 3; j++) {//Save all fit parameters in the array
+            _pixelLayerFitParams[i][j] = fit->GetParameter(j);
+        }
+
+    }
+
+    for (int i = 0; i < NUMBER_OF_LAYER; i++) {
+        streamlog_out(MESSAGE) << "\n Fit PARAMS for layer " << i;//Printing all fit parameters for each layer
+        for (int j = 0; j < 3; j++) {
+            streamlog_out(MESSAGE) << "\n par["<< j <<"] = "<< _layerFitParams[i][j];
+        }
+        MIP.push_back(_layerFitParams[i][1]);
+    }
     std::cout << '\n';
 
-	}
+    // Print out the vector
+    for (float n : MIP) std::cout << n << ' ';
+    std::cout << '\n';
+}


### PR DESCRIPTION
## Changelog
Updates on GetMIP processor:
- Parameters in .xml file can be read by the processor via `register...` functions, given the parameter name matches the relative argument in the `register...`;
- ECAL size and fitting parameters are put in the head file (all captalised);
- `ShowECALInfo` now has a cousin `ShowPixelECALInfo`. They work for the two kinds of input, the monolithic and the pixelised;
- Fitting function has initial parameters and limits on them to make the fit work. However, the limits are fine tuned now to make all 30 fits reasonable;
- Fit results are written into two histograms `_fittedMIP` and `_fittedPixelMIP`, with each bin stands for a layer;

Updates on GetEnergyResolution processor:
- Only the collections that have registered in the .xml file are read in the processor; a collection can be skipped by commenting-out the entry;
- `ShowDigitECALInfo`, another cousin of `ShowECALInfo`, is added to process the digitised ECAL information in the collection of the type `CalorimeterHits`;
- Fits are done within a radius (e.g. 2 sigmas) around the mean value; the histogram limits `xmin` and `xmax` are variable;

Updates on ROOT plotting macro:
- Read a bunch of file from a file list, instead of looping through a filename pattern;
- Use `std::map` to store input data, namely the fit results per energy;
- LuxeStyle;

## Notes
on GetMIP processor:
- Histogram names in ROOT lose their initial `_`;
- Messaging options changed to `DEBUG` (however, the messages are not shown so far even with the verbosity option changed);
- Axes labels updates;
- Array's initial values now set by `std::fill()`; `... = {0}` only sets the first member;
on GetEnergyResolution processor:
- Histograms per layer are no longer fitted, since they normally do not follow Gaussian distribution;
- Showing four sets of data on ECALs of monolithic, pixelised, digitised _sin_ smearing, and digitised _con_ smearing;